### PR TITLE
criado o gitignore e o config.example.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/*
+config.php

--- a/config.example.php
+++ b/config.example.php
@@ -10,7 +10,7 @@ define( 'ABSPATH', dirname( __FILE__ ) );
 define( 'UP_ABSPATH', ABSPATH . '\views\_uploads' );
 
 // URL da home
-define( 'HOME_URI', '/igrana' );
+define( 'HOME_URI', '' );
 
 // Nome do host da base de dados
 define( 'HOSTNAME', 'localhost' );
@@ -28,7 +28,7 @@ define( 'DB_PASSWORD', 'dbpassword' );
 define( 'DB_CHARSET', 'utf8' );
 
 // Se você estiver desenvolvendo, modifique o valor para true
-define( 'DEBUG', true );
+define( 'DEBUG', false );
 
 /**
  * Não edite daqui em diante


### PR DESCRIPTION
Normalmente criamos um arquivo de config.example para ter um modelo para não ter os dados de senha e endereço de base de dados diretamente no repositório.